### PR TITLE
Implemented wildcards and ranges for image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,50 @@ For every pair of containers with the same name, `rocker-compose` does a compari
 
 **state: created** is mostly used for data volume and network-share containers. They are described in the [patterns](#patterns) section.
 
+# Image
+Image could be specified using following syntax `[registry/][repo/]name[:tag]`, where everything except name is optional, in case when registry is not specified explicitly - central docker [Hub](https://hub.docker.com/explore/) will be used. If tag won't be set explicitly, `rocker-compose` will use the `latest` tag if it's available locally or from the repository or will use the most recent version of an image.
+   
+Additionally, `rocker-compose` supports [semantic versioning](http://semver.org/), wildcards and version ranges in tags. Instead of setting new version of image each time newer version of your image should be deployed, it's possible to specify criteria of an image and `rocker-compose` will be able to pull and run it without changing a manifest.
+    
+Example:   
+```yaml
+namespace: example
+containers:
+  container_strict:
+    # in this case `rocker-compose` will get and run exactly specified version 
+    image: ubuntu:14.04.1 
+    cmd: "/bin/bash" 
+  
+  container_latest:
+    # in this case as well as `ubuntu:x`, `ubuntu:` or simply `ubuntu` - `rocker-compose` will pull/run the most recent version or will use tag `latest` if it's available
+    image: ubuntu:* 
+    cmd: "/bin/bash"
+     
+  container_any_14_04:
+      # in this case as well as `ubuntu:14.04.x` - rocker compose will retrieve all applicable tags and choose the biggest version. (`14.04.3` in this case)
+      image: ubuntu:14.04.*
+      cmd: "/bin/bash"
+         
+  container_after_14_04_2:
+        # in this case range is specified: it means that `rocker-compose` should use version grater or equal to `14.04.2`. (`14.04.3` in this case)
+        image: ubuntu:~14.04.2
+        cmd: "/bin/bash"
+                  
+  container_after_14:
+          # range could be used in any dimension, here version >= 14 is set, which will lead to running `ubuntu:14.10`
+          image: ubuntu:~14
+          cmd: "/bin/bash"  
+                                  
+  container_invalid:
+          # tags which don't comply with semver 2.0 standard, don't have features described above (ranges, wildcards) and you will get an error during deployment
+          image: ubuntu:wily-2015* # This won't work as a wildcard, otherwise `rocker-compose` will try to get image `ubuntu:wily-2015*` 
+          cmd: "/bin/bash"                                  
+```
+
+*NOTE: that if version is specified but pull wasn't done, `rocker-compose` will use the most recent pulled version or it will pull it on their own, if there is no applicable image in local cache*
+
+*NOTE: if newer image is available - container will be updated and restarted automatically (in case if you need a flag to prevent this - create an issue)*
+
 # Volumes
 It is possible to mount volumes to a running container the same way as it is when using plain `docker run`. In Docker, there are two types of volumes: **Data volume** and **Mounted host directory**. 
 

--- a/src/cmd/rocker-compose/main.go
+++ b/src/cmd/rocker-compose/main.go
@@ -132,6 +132,10 @@ func main() {
 					Usage: "Force recreation of current configuration",
 				},
 				cli.BoolFlag{
+					Name:  "upgrade, u",
+					Usage: "Force recreation of containers which have greater version",
+				},
+				cli.BoolFlag{
 					Name:  "attach",
 					Usage: "Stream stdout of all containers to log",
 				},
@@ -250,6 +254,7 @@ func runCommand(ctx *cli.Context) {
 		Attach:   ctx.Bool("attach"),
 		Wait:     ctx.Duration("wait"),
 		Pull:     ctx.Bool("pull"),
+		Upgrade:  ctx.Bool("upgrade"),
 		Auth:     auth,
 	})
 

--- a/src/cmd/rocker-compose/main.go
+++ b/src/cmd/rocker-compose/main.go
@@ -132,10 +132,6 @@ func main() {
 					Usage: "Force recreation of current configuration",
 				},
 				cli.BoolFlag{
-					Name:  "upgrade, u",
-					Usage: "Force recreation of containers which have greater version",
-				},
-				cli.BoolFlag{
 					Name:  "attach",
 					Usage: "Stream stdout of all containers to log",
 				},
@@ -254,7 +250,6 @@ func runCommand(ctx *cli.Context) {
 		Attach:   ctx.Bool("attach"),
 		Wait:     ctx.Duration("wait"),
 		Pull:     ctx.Bool("pull"),
-		Upgrade:  ctx.Bool("upgrade"),
 		Auth:     auth,
 	})
 

--- a/src/compose/client.go
+++ b/src/compose/client.go
@@ -368,7 +368,7 @@ func (client *DockerClient) Clean(config *config.Config) error {
 	// collect tags for every image
 	for _, image := range all {
 		for _, repoTag := range image.RepoTags {
-			imageName := imagename.New(repoTag)
+			imageName := imagename.NewFromString(repoTag)
 			for img := range images {
 				if img.IsSameKind(*imageName) {
 					images[img].Items = append(images[img].Items, &imagename.Tag{

--- a/src/compose/client.go
+++ b/src/compose/client.go
@@ -37,7 +37,7 @@ type Client interface {
 	RunContainer(container *Container) error
 	EnsureContainerExist(name *Container) error
 	EnsureContainerState(name *Container) error
-	PullAll(config *config.Config) error
+	PullAll(containers []*Container) error
 	Clean(config *config.Config) error
 	AttachToContainers(container []*Container) error
 	AttachToContainer(container *Container) error
@@ -317,21 +317,9 @@ func (client *DockerClient) EnsureContainerState(container *Container) error {
 }
 
 // PullAll grabs all image names from containers in spec and pulls all of them
-func (client *DockerClient) PullAll(config *config.Config) error {
-	// do not pull same image twice
-	pulledImages := map[string]struct{}{}
-	containers := GetContainersFromConfig(config)
-
-	// do pull
-	for _, container := range containers {
-		imageName := container.Image.String()
-		if _, ok := pulledImages[imageName]; ok {
-			continue
-		}
-		if err := client.pullImageForContainer(container, true); err != nil {
-			return err
-		}
-		pulledImages[imageName] = struct{}{}
+func (client *DockerClient) PullAll(containers []*Container) error {
+	if err := client.pullImageForContainers(true, containers...); err != nil {
+		return err
 	}
 	return nil
 }
@@ -510,64 +498,10 @@ func (client *DockerClient) WaitForContainer(container *Container) (err error) {
 
 // FetchImages
 func (client *DockerClient) FetchImages(containers []*Container) error {
-	type message struct {
-		container *Container
-		result    chan error
+	if err := client.pullImageForContainers(false, containers...); err != nil {
+		return err
 	}
-
-	wg := util.NewErrorWaitGroup(len(containers))
-	chPullImages := make(chan message)
-	done := make(chan struct{}, 1)
-	checkedImages := map[string]struct{}{}
-
-	// Pull worker
-	// We do not want to pull images in parallel
-	// instead, we use an actor to pull images sequentially
-	//
-	// TODO: WAAAT? we can simplify it by going though a list of images sequentially
-	// 			 and pull those images which are missing.
-	go func() {
-		for {
-			select {
-			case msg := <-chPullImages:
-				msg.result <- client.pullImageForContainer(msg.container, false)
-			case <-done:
-				return
-			}
-		}
-	}()
-
-	defer func() {
-		done <- struct{}{}
-	}()
-
-	for _, container := range containers {
-		if container.Image == nil {
-			return fmt.Errorf("Image is not specified for container %s", container.Name)
-		}
-		if _, ok := checkedImages[container.Image.String()]; ok {
-			wg.Done(nil)
-			continue
-		}
-		checkedImages[container.Image.String()] = struct{}{}
-
-		go func(container *Container) {
-			image, err := client.Docker.InspectImage(container.Image.String())
-			if err == docker.ErrNoSuchImage {
-				msg := message{container, make(chan error)}
-				chPullImages <- msg
-				wg.Done(<-msg.result)
-				return
-			} else if err != nil {
-				wg.Done(err)
-				return
-			}
-			container.ImageId = image.ID
-			wg.Done(nil)
-		}(container)
-	}
-
-	return wg.Wait()
+	return nil
 }
 
 // GetPulledImages returns the list of images pulled by a recent run
@@ -582,20 +516,79 @@ func (client *DockerClient) GetRemovedImages() []*imagename.ImageName {
 
 // Internal
 
-func (client *DockerClient) pullImageForContainer(container *Container, force bool) (err error) {
-	if container.Image == nil {
-		err = fmt.Errorf("Image is not specified for container: %s", container.Name)
+// pullImageForContainers pulls required images to container daemon storage
+// forceUpdate: bool if true - will ensure that the most recent version of required image will be pulled
+// containers: []Container - list of containers list of images should be pulled for
+func (client *DockerClient) pullImageForContainers(forceUpdate bool, containers ...*Container) (err error) {
+	pulled := map[string]struct{}{}
+
+	//getting all images that we already have
+	var images []*imagename.ImageName
+	if images, err = client.getAllImageNames(); err != nil {
 		return
 	}
 
-	log.Infof("Pulling image: %s for %s", container.Image, container.Name)
-	var img *imagename.ImageName
-	if img, err = PullDockerImage(client.Docker, container.Image, client.Auth.ToDockerApi(), force); err != nil {
-		err = fmt.Errorf("Failed to pull image %s for container %s, error: %s", container.Image, container.Name, err)
-		return
+	// check images for each container
+	for _, container := range containers {
+		// error in configuration, fail fast
+		if container.Image == nil {
+			err = fmt.Errorf("Image is not specified for container: %s", container.Name)
+			return
+		}
+
+		// already pulled it for other container, skip
+		if _, ok := pulled[container.Image.String()]; ok {
+			continue
+		}
+
+		pulled[container.Image.String()] = struct{}{}
+
+		// looking locally first
+		candidate := findMostRecentTag(container.Image, images)
+
+		log.Debugf("Found %s at local repository", candidate)
+
+		// force update if we don't find anything locally
+		forceUpdate = forceUpdate || candidate == nil
+
+		// in case we want to include external images as well, pulling list of available
+		// images from repository or central docker hub
+		if forceUpdate {
+			hub := imagename.NewDockerHub()
+			var remote []*imagename.ImageName
+			if remote, err = hub.List(container.Image); err != nil {
+				err = fmt.Errorf("Failed to pull image %s for container %s from remote registry, error: %s",
+					container.Image, container.Name, err)
+			} else {
+				images = append(images, remote...)
+			}
+
+			// getting the most applicable image
+			// it may be local or remote image, it depends of forceUpdate flag
+			candidate = findMostRecentTag(container.Image, images)
+			log.Debugf("Found %s at remote repository", candidate)
+		}
+
+		if _, err = client.Docker.InspectImage(candidate.String()); err == docker.ErrNoSuchImage {
+			log.Infof("Pulling image: %s for %s", candidate, container.Name)
+			if err = PullDockerImage(client.Docker, candidate, client.Auth.ToDockerApi()); err != nil {
+				err = fmt.Errorf("Failed to pull image %s for container %s, error: %s", container.Image, container.Name, err)
+				return
+			}
+		}
+
+		if err != nil {
+			return
+		}
+
+		log.Debugf("Image %s is the most recent image for container: %s", candidate, container.Name)
+
+		//saving resolved image in case we want to run this container
+		container.ImageResolved = candidate
+
+		client.pulledImages = append(client.pulledImages, container.Image)
 	}
-	container.Image = img
-	client.pulledImages = append(client.pulledImages, container.Image)
+
 	return
 }
 
@@ -703,4 +696,56 @@ func (client *DockerClient) flushContainerLogs(container *Container) {
 	if err2 != nil {
 		log.Errorf("Failed to read logs of container %s, error: %s", container.Name, err2)
 	}
+}
+
+func (client *DockerClient) getAllImageNames() (images []*imagename.ImageName, err error) {
+	var dockerImages []docker.APIImages
+
+	// retrieving images currently available in docker
+	if dockerImages, err = client.Docker.ListImages(docker.ListImagesOptions{}); err != nil {
+		return
+	}
+
+	for _, image := range dockerImages {
+		for _, repoTag := range image.RepoTags {
+			images = append(images, imagename.NewFromString(repoTag))
+		}
+	}
+
+	return
+}
+
+// findMostRecentTag getting all applicable version from dockerhub and choose the most recent
+func findMostRecentTag(image *imagename.ImageName, list []*imagename.ImageName) (img *imagename.ImageName) {
+	for _, candidate := range list {
+		if !image.Contains(candidate) {
+			//this image is from the same name/registry but tag is not applicable
+			// e.g. ~1.2.3 contains 1.2.5, but it's not true for 1.3.0
+			continue
+		}
+
+		if candidate.GetTag() == imagename.Latest {
+			// use latest if it's possible
+			img = candidate
+			return
+		}
+
+		if img == nil {
+			img = candidate
+			continue
+		}
+
+		// uncomparable candidate... skipping
+		if !candidate.HasVersion() {
+			continue
+		}
+
+		// if both names has versions to compare, we cat safely compare them
+		if img.HasVersion() && candidate.HasVersion() && img.TagAsVersion().Less(candidate.TagAsVersion()) {
+			img = candidate
+			log.Debugf("Replacing %s with %s", img, candidate)
+		}
+	}
+
+	return
 }

--- a/src/compose/client_test.go
+++ b/src/compose/client_test.go
@@ -191,7 +191,7 @@ containers:
 	n := 0
 	for _, image := range all {
 		for _, repoTag := range image.RepoTags {
-			imageName := imagename.New(repoTag)
+			imageName := imagename.NewFromString(repoTag)
 			if imageName.Name == "rocker-compose-test-image-clean" {
 				n++
 			}
@@ -205,7 +205,7 @@ containers:
 	removed := cli.GetRemovedImages()
 	assert.Equal(t, 3, len(removed), "Expected to remove a particular number of images")
 
-	assert.EqualValues(t, &imagename.ImageName{"", "rocker-compose-test-image-clean", "3"}, removed[0], "removed wrong image")
-	assert.EqualValues(t, &imagename.ImageName{"", "rocker-compose-test-image-clean", "2"}, removed[1], "removed wrong image")
-	assert.EqualValues(t, &imagename.ImageName{"", "rocker-compose-test-image-clean", "1"}, removed[2], "removed wrong image")
+	assert.EqualValues(t, imagename.New("rocker-compose-test-image-clean", "3"), removed[0], "removed wrong image")
+	assert.EqualValues(t, imagename.New("rocker-compose-test-image-clean", "2"), removed[1], "removed wrong image")
+	assert.EqualValues(t, imagename.New("rocker-compose-test-image-clean", "1"), removed[2], "removed wrong image")
 }

--- a/src/compose/compose.go
+++ b/src/compose/compose.go
@@ -42,7 +42,6 @@ type ComposeConfig struct {
 	DryRun     bool
 	Attach     bool
 	Pull       bool
-	Upgrade    bool
 	Remove     bool
 	Recover    bool
 	Wait       time.Duration
@@ -56,7 +55,6 @@ type Compose struct {
 	DryRun   bool
 	Attach   bool
 	Pull     bool
-	Upgrade  bool
 	Remove   bool
 	Wait     time.Duration
 
@@ -72,7 +70,6 @@ func New(config *ComposeConfig) (*Compose, error) {
 		Manifest: config.Manifest,
 		DryRun:   config.DryRun,
 		Attach:   config.Attach,
-		Upgrade:  config.Upgrade,
 		Pull:     config.Pull,
 		Wait:     config.Wait,
 		Remove:   config.Remove,
@@ -124,10 +121,10 @@ func (compose *Compose) RunAction() error {
 		return fmt.Errorf("Failed to fetch images of given containers, error: %s", err)
 	}
 
-	if compose.Upgrade {
-		for _, container := range expected {
-			container.Image = container.ImageResolved
-		}
+	//upgrading expected image to the most recent
+	// todo: it may be an option to skip this step in some cases
+	for _, container := range expected {
+		container.Image = container.ImageResolved
 	}
 
 	// Assign IDs of existing containers

--- a/src/compose/compose.go
+++ b/src/compose/compose.go
@@ -42,6 +42,7 @@ type ComposeConfig struct {
 	DryRun     bool
 	Attach     bool
 	Pull       bool
+	Upgrade    bool
 	Remove     bool
 	Recover    bool
 	Wait       time.Duration
@@ -55,6 +56,7 @@ type Compose struct {
 	DryRun   bool
 	Attach   bool
 	Pull     bool
+	Upgrade  bool
 	Remove   bool
 	Wait     time.Duration
 
@@ -70,6 +72,7 @@ func New(config *ComposeConfig) (*Compose, error) {
 		Manifest: config.Manifest,
 		DryRun:   config.DryRun,
 		Attach:   config.Attach,
+		Upgrade:  config.Upgrade,
 		Pull:     config.Pull,
 		Wait:     config.Wait,
 		Remove:   config.Remove,
@@ -119,6 +122,12 @@ func (compose *Compose) RunAction() error {
 		}
 	} else if err := compose.client.FetchImages(expected); err != nil {
 		return fmt.Errorf("Failed to fetch images of given containers, error: %s", err)
+	}
+
+	if compose.Upgrade {
+		for _, container := range expected {
+			container.Image = container.ImageResolved
+		}
 	}
 
 	// Assign IDs of existing containers

--- a/src/compose/config/compare_test.go
+++ b/src/compose/config/compare_test.go
@@ -79,7 +79,7 @@ func TestConfigIsEqualTo(t *testing.T) {
 	cases := tests{
 		// type: string
 		fieldSpec{
-			[]string{"Image", "Pid", "Uts", "CpusetCpus", "Hostname", "Domainname", "User", "Workdir"},
+			[]string{"Pid", "Uts", "CpusetCpus", "Hostname", "Domainname", "User", "Workdir"},
 			[]check{
 				check{shouldEqual, "KEY: foo", "KEY: foo"},
 				check{shouldEqual, "", ""},

--- a/src/compose/config/config.go
+++ b/src/compose/config/config.go
@@ -339,7 +339,10 @@ func ReadConfig(configName string, reader io.Reader, vars map[string]interface{}
 		if container.Image == nil {
 			return nil, fmt.Errorf("Image should be specified for container: %s", name)
 		}
-		if !imagename.NewFromString(*container.Image).HasTag() {
+
+		img := imagename.NewFromString(*container.Image)
+
+		if !img.IsStrict() && !img.HasVersionRange() && !img.All() {
 			return nil, fmt.Errorf("Image `%s` for container `%s`: image without tag is not allowed",
 				*container.Image, name)
 		}

--- a/src/compose/config/config.go
+++ b/src/compose/config/config.go
@@ -339,7 +339,7 @@ func ReadConfig(configName string, reader io.Reader, vars map[string]interface{}
 		if container.Image == nil {
 			return nil, fmt.Errorf("Image should be specified for container: %s", name)
 		}
-		if !imagename.New(*container.Image).HasTag() {
+		if !imagename.NewFromString(*container.Image).HasTag() {
 			return nil, fmt.Errorf("Image `%s` for container `%s`: image without tag is not allowed",
 				*container.Image, name)
 		}

--- a/src/compose/config/config_test.go
+++ b/src/compose/config/config_test.go
@@ -90,16 +90,6 @@ containers:
 	assert.Equal(t, "Image should be specified for container: test", err.Error())
 }
 
-func TestConfigImageNoTag(t *testing.T) {
-	configStr := `namespace: test
-containers:
-  test:
-    image: ubuntu`
-
-	_, err := ReadConfig("test", strings.NewReader(configStr), configTestVars, map[string]interface{}{})
-	assert.Equal(t, "Image `ubuntu` for container `test`: image without tag is not allowed", err.Error())
-}
-
 func TestNewContainerNameFromString(t *testing.T) {
 	type assertion struct {
 		namespace string

--- a/src/compose/config/reflect.go
+++ b/src/compose/config/reflect.go
@@ -24,6 +24,7 @@ import (
 
 // compareSkipFields defines which fields will not be compared
 var compareSkipFields = []string{
+	"Image",
 	"Extends",
 	"KillTimeout",
 	"NetworkDisabled",

--- a/src/compose/container.go
+++ b/src/compose/container.go
@@ -151,7 +151,7 @@ func (a *Container) IsEqualTo(b *Container) bool {
 	}
 
 	// check image version
-	if !a.Image.Contains(b.Image) {
+	if a.Image != nil && !a.Image.Contains(b.Image) {
 		log.Debugf("Comparing '%s' and '%s': image version '%s' is not satisfied (was %s should satisfy %s)",
 			a.Name.String(),
 			b.Name.String(),

--- a/src/compose/container.go
+++ b/src/compose/container.go
@@ -80,7 +80,7 @@ func NewContainerFromConfig(name *config.ContainerName, containerConfig *config.
 		Config: containerConfig,
 	}
 	if containerConfig.Image != nil {
-		container.Image = imagename.New(*containerConfig.Image)
+		container.Image = imagename.NewFromString(*containerConfig.Image)
 	}
 	return container
 }
@@ -94,7 +94,7 @@ func NewContainerFromDocker(dockerContainer *docker.Container) (*Container, erro
 	}
 	return &Container{
 		Id:      dockerContainer.ID,
-		Image:   imagename.New(dockerContainer.Config.Image),
+		Image:   imagename.NewFromString(dockerContainer.Config.Image),
 		ImageId: dockerContainer.Image,
 		Name:    config.NewContainerNameFromString(dockerContainer.Name),
 		Created: dockerContainer.Created,

--- a/src/compose/container.go
+++ b/src/compose/container.go
@@ -206,6 +206,9 @@ func (container *Container) CreateContainerOptions() (*docker.CreateContainerOpt
 
 	apiConfig.Labels = labels
 
+	// Replace image with more specific one (config may contain image range or wildcards)
+	apiConfig.Image = container.Image.String()
+
 	return &docker.CreateContainerOptions{
 		Name:       container.Name.String(),
 		Config:     apiConfig,

--- a/src/compose/container_test.go
+++ b/src/compose/container_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/grammarly/rocker/src/rocker/imagename"
 	"github.com/stretchr/testify/assert"
+	"github.com/wmark/semver"
 )
 
 var (
@@ -86,10 +87,12 @@ func TestNewContainerFromDocker(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rang, _ := semver.NewRange("1.9.2")
 	assertionImage := &imagename.ImageName{
 		Registry: "quay.io",
 		Name:     "myapp",
 		Tag:      "1.9.2",
+		Version:  rang,
 	}
 	assertionName := &config.ContainerName{
 		Namespace: "myapp",

--- a/src/compose/diff_test.go
+++ b/src/compose/diff_test.go
@@ -463,8 +463,8 @@ func (m *clientMock) PullImage(imageName *imagename.ImageName) error {
 	return args.Error(0)
 }
 
-func (m *clientMock) PullAll(cfg *config.Config) error {
-	args := m.Called(cfg)
+func (m *clientMock) PullAll(container []*Container) error {
+	args := m.Called(container)
 	return args.Error(0)
 }
 

--- a/src/compose/docker.go
+++ b/src/compose/docker.go
@@ -86,7 +86,7 @@ func GetBridgeIp(client *docker.Client) (ip string, err error) {
 	_, err = client.InspectImage(emptyImageName)
 	if err != nil && err.Error() == "no such image" {
 		log.Infof("Pulling image %s to obtain network bridge address", emptyImageName)
-		if err := PullDockerImage(client, imagename.New(emptyImageName), &docker.AuthConfiguration{}); err != nil {
+		if err := PullDockerImage(client , imagename.NewFromString(emptyImageName), &docker.AuthConfiguration{}); err != nil {
 			return "", err
 		}
 	} else if err != nil {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -92,17 +92,17 @@
 			"path": "/src/rocker/test"
 		},
 		{
-			"importpath": "github.com/grammarly/rocker/src/rocker/imagename",
-			"repository": "https://github.com/grammarly/rocker",
-			"revision": "6757596a73489d7224fc9fb64a073027cce79d4d",
-			"branch": "master",
-			"path": "/src/rocker/imagename"
-		},
-		{
 			"importpath": "github.com/wmark/semver",
 			"repository": "https://github.com/wmark/semver",
 			"revision": "461c06b538be53cc0339815001a398e29ace025b",
 			"branch": "master"
+		},
+		{
+			"importpath": "github.com/grammarly/rocker/src/rocker/imagename",
+			"repository": "https://github.com/grammarly/rocker",
+			"revision": "c3d3b9df9b1dfa5e8aeeb59a973ab9f17788d18f",
+			"branch": "master",
+			"path": "/src/rocker/imagename"
 		}
 	]
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -100,7 +100,7 @@
 		{
 			"importpath": "github.com/grammarly/rocker/src/rocker/imagename",
 			"repository": "https://github.com/grammarly/rocker",
-			"revision": "c3d3b9df9b1dfa5e8aeeb59a973ab9f17788d18f",
+			"revision": "ed539c1430e23bd6ac6821b65d9ae98465e12322",
 			"branch": "master",
 			"path": "/src/rocker/imagename"
 		}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -85,18 +85,18 @@
 			"branch": "master"
 		},
 		{
-			"importpath": "github.com/grammarly/rocker/src/rocker/imagename",
-			"repository": "https://github.com/grammarly/rocker",
-			"revision": "77d2615f9b36f7c9997ed3a11519767a07f20a5b",
-			"branch": "master",
-			"path": "/src/rocker/imagename"
-		},
-		{
 			"importpath": "github.com/grammarly/rocker/src/rocker/test",
 			"repository": "https://github.com/grammarly/rocker",
 			"revision": "622658981ffda1621fd8755b7b9b1498336c06c1",
 			"branch": "master",
 			"path": "/src/rocker/test"
+		},
+		{
+			"importpath": "github.com/grammarly/rocker/src/rocker/imagename",
+			"repository": "https://github.com/grammarly/rocker",
+			"revision": "6757596a73489d7224fc9fb64a073027cce79d4d",
+			"branch": "master",
+			"path": "/src/rocker/imagename"
 		}
 	]
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -100,7 +100,7 @@
 		{
 			"importpath": "github.com/grammarly/rocker/src/rocker/imagename",
 			"repository": "https://github.com/grammarly/rocker",
-			"revision": "fa75cd1a6da04f1caaa90fa3879c517a59e251ac",
+			"revision": "65f83f456d8214103544b41a06d9b6663938ce4c",
 			"branch": "master",
 			"path": "/src/rocker/imagename"
 		}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -97,6 +97,12 @@
 			"revision": "6757596a73489d7224fc9fb64a073027cce79d4d",
 			"branch": "master",
 			"path": "/src/rocker/imagename"
+		},
+		{
+			"importpath": "github.com/wmark/semver",
+			"repository": "https://github.com/wmark/semver",
+			"revision": "461c06b538be53cc0339815001a398e29ace025b",
+			"branch": "master"
 		}
 	]
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -100,7 +100,7 @@
 		{
 			"importpath": "github.com/grammarly/rocker/src/rocker/imagename",
 			"repository": "https://github.com/grammarly/rocker",
-			"revision": "ed539c1430e23bd6ac6821b65d9ae98465e12322",
+			"revision": "fa75cd1a6da04f1caaa90fa3879c517a59e251ac",
 			"branch": "master",
 			"path": "/src/rocker/imagename"
 		}

--- a/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/dockerhub.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/dockerhub.go
@@ -1,0 +1,93 @@
+package imagename
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+type tags struct {
+	Name string   `json:"name,omitempty"`
+	Tags []string `json:"tags,omitempty"`
+}
+
+type history struct {
+	Compatibility string `json:"v1Compatibility,omitempty"`
+}
+
+type manifests struct {
+	Name          string     `json:"name,omitempty"`
+	Tag           string     `json:"tag,omitempty"`
+	Architecture  string     `json:"architecture,omitempty"`
+	History       []*history `json:"history,omitempty"`
+	SchemaVersion int        `json:"schemaVersion,omitempty"`
+}
+
+type DockerHub struct{}
+
+func NewDockerHub() *DockerHub {
+	return &DockerHub{}
+}
+
+func (h *DockerHub) Get(image *ImageName) (img *docker.Image, err error) {
+	manifest := manifests{}
+	img = &docker.Image{}
+	if err = h.doGet(fmt.Sprintf("https://%s/v2/%s/manifests/%s", image.Registry, image.Name, image.Tag), &manifest); err != nil {
+		return
+	}
+
+	if len(manifest.History) == 0 {
+		err = fmt.Errorf("Image doesn't have expected format, history record is empty")
+		return
+	}
+
+	last := manifest.History[0]
+	err = json.Unmarshal([]byte(last.Compatibility), img)
+	return
+}
+
+func (h *DockerHub) List(image *ImageName) (images []*ImageName, err error) {
+	tg := tags{}
+	if err = h.doGet(fmt.Sprintf("https://%s/v2/%s/tags/list", image.Registry, image.Name), &tg); err != nil {
+		return
+	}
+	for _, t := range tg.Tags {
+		candidate := New(image.NameWithRegistry(), t)
+		if image.Contains(candidate) {
+			images = append(images, candidate)
+		}
+	}
+	return
+}
+
+func (h *DockerHub) doGet(url string, obj interface{}) (err error) {
+	var res *http.Response
+	var body []byte
+
+	res, err = http.Get(url)
+	if err != nil {
+		err = fmt.Errorf("Request to %s failed with %s\n", url, err)
+		return
+	}
+
+	if res.StatusCode == 404 {
+		err = fmt.Errorf("Not found")
+		return
+	}
+
+	if body, err = ioutil.ReadAll(res.Body); err != nil {
+		err = fmt.Errorf("Response from %s cannot be read due to error %s\n", url, err)
+		return
+	}
+
+	if err = json.Unmarshal(body, obj); err != nil {
+		err = fmt.Errorf("Response from %s cannot be unmarshalled due to error %s, response: %s\n",
+			url, err, string(body))
+		return
+	}
+
+	return
+}

--- a/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename.go
@@ -19,10 +19,7 @@ type ImageName struct {
 }
 
 func (dockerImage ImageName) GetTag() string {
-	if dockerImage.IsStrict() {
-		return dockerImage.Tag
-	}
-	return Latest
+	return dockerImage.Tag
 }
 
 func (dockerImage ImageName) IsStrict() bool {

--- a/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename.go
@@ -1,32 +1,21 @@
-/*-
- * Copyright 2015 Grammarly, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package imagename
 
 import (
+	"github.com/wmark/semver"
 	"sort"
 	"strings"
 )
 
-const Latest = "latest"
+const (
+	Latest    = "latest"
+	Wildcards = "x*"
+)
 
 type ImageName struct {
 	Registry string
 	Name     string
 	Tag      string
+	Version  *semver.Range
 }
 
 func (dockerImage ImageName) GetTag() string {
@@ -37,7 +26,11 @@ func (dockerImage ImageName) GetTag() string {
 }
 
 func (dockerImage ImageName) HasTag() bool {
-	return dockerImage.Tag != ""
+	return dockerImage.Tag != "" && !strings.ContainsAny(dockerImage.Tag, Wildcards)
+}
+
+func (dockerImage ImageName) HasVersion() bool {
+	return dockerImage.Version != nil
 }
 
 func (a ImageName) IsSameKind(b ImageName) bool {
@@ -56,20 +49,64 @@ func (dockerImage ImageName) String() string {
 	return dockerImage.NameWithRegistry() + ":" + dockerImage.GetTag()
 }
 
-func New(image string) *ImageName {
-	dockerImage := &ImageName{}
+func NewFromString(image string) *ImageName {
 	split := strings.SplitN(image, ":", 2)
-	if strings.Contains(split[0], ".") || len(strings.SplitN(image, "/", 3)) > 2 {
-		registryAndName := strings.SplitN(split[0], "/", 2)
+	if len(split) > 1 {
+		return New(split[0], split[1])
+	}
+	return New(split[0], "")
+}
+
+func New(image string, tag string) *ImageName {
+	dockerImage := &ImageName{}
+	if strings.Contains(image, ".") || len(strings.SplitN(image, "/", 3)) > 2 {
+		registryAndName := strings.SplitN(image, "/", 2)
 		dockerImage.Registry = registryAndName[0]
 		dockerImage.Name = registryAndName[1]
 	} else {
-		dockerImage.Name = split[0]
+		dockerImage.Name = image
 	}
-	if len(split) > 1 {
-		dockerImage.Tag = split[1]
+	if tag != "" {
+		if rng, err := semver.NewRange(tag); err == nil && rng != nil {
+			dockerImage.Version = rng
+		}
+		if ver, err := semver.NewVersion(strings.TrimLeft(tag, "v")); (err == nil && ver != nil) || dockerImage.Version == nil || strings.ContainsAny(tag, Wildcards) {
+			dockerImage.Tag = tag
+		}
 	}
 	return dockerImage
+}
+
+func (dockerImage ImageName) Contains(b *ImageName) bool {
+	if b == nil {
+		return false
+	}
+
+	if dockerImage.Name != b.Name || dockerImage.Registry != b.Registry {
+		return false
+	}
+
+	if strings.ContainsAny(dockerImage.Tag, Wildcards) {
+		return true
+	}
+
+	if dockerImage.HasTag() && dockerImage.Tag == b.Tag {
+		return true
+	}
+
+	if dockerImage.HasVersion() && dockerImage.Version.IsSatisfiedBy(b.TagAsVersion()) {
+		return true
+	}
+
+	return !dockerImage.HasTag() && !dockerImage.HasVersion()
+}
+
+func (dockerImage ImageName) TagAsVersion() (ver *semver.Version) {
+	if !dockerImage.HasTag() {
+		return nil
+	}
+	ver, _ = semver.NewVersion(dockerImage.Tag)
+	return
 }
 
 // Type structures used for cleaning images

--- a/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename.go
@@ -26,7 +26,7 @@ func (dockerImage ImageName) GetTag() string {
 }
 
 func (dockerImage ImageName) HasTag() bool {
-	return dockerImage.Tag != "" && !strings.ContainsAny(dockerImage.Tag, Wildcards)
+	return dockerImage.Tag != "" && !strings.Contains(Wildcards, dockerImage.Tag)
 }
 
 func (dockerImage ImageName) HasVersion() bool {
@@ -70,7 +70,7 @@ func New(image string, tag string) *ImageName {
 		if rng, err := semver.NewRange(tag); err == nil && rng != nil {
 			dockerImage.Version = rng
 		}
-		if ver, err := semver.NewVersion(strings.TrimLeft(tag, "v")); (err == nil && ver != nil) || dockerImage.Version == nil || strings.ContainsAny(tag, Wildcards) {
+		if ver, err := semver.NewVersion(strings.TrimLeft(tag, "v")); (err == nil && ver != nil) || dockerImage.Version == nil || strings.Contains(Wildcards, tag) {
 			dockerImage.Tag = tag
 		}
 	}
@@ -86,7 +86,9 @@ func (dockerImage ImageName) Contains(b *ImageName) bool {
 		return false
 	}
 
-	if strings.ContainsAny(dockerImage.Tag, Wildcards) {
+	// semver library has a bug with wildcards, so this checks are
+	// necessary: empty range (or wildcard range) cannot contains any version, it just fails
+	if dockerImage.Tag != "" && strings.Contains(Wildcards, dockerImage.Tag) {
 		return true
 	}
 

--- a/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename_test.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename_test.go
@@ -1,19 +1,3 @@
-/*-
- * Copyright 2015 Grammarly, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package imagename
 
 import (
@@ -21,38 +5,143 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wmark/semver"
 )
 
 func TestImageParsingWithoutNamespace(t *testing.T) {
-	img := New("repo/name:1")
+	img := NewFromString("repo/name:1")
 	assert.Equal(t, "", img.Registry)
 	assert.Equal(t, "1", img.Tag)
 	assert.Equal(t, "repo/name", img.Name)
+	assert.True(t, img.Contains(NewFromString("repo/name:1")))
+}
+
+func TestWildcardNamespace(t *testing.T) {
+	img := NewFromString("repo/name:*")
+	assert.Empty(t, img.Registry)
+	assert.Equal(t, "*", img.Tag)
+	assert.Equal(t, "repo/name", img.Name)
+	assert.True(t, img.Contains(NewFromString("repo/name:1.0.0")))
 }
 
 func TestImageRealLifeNamingExample(t *testing.T) {
-	img := New("quay.io/platform/dockerize:v0.0.1")
-	assert.Equal(t, "quay.io", img.Registry)
+	img := NewFromString("dockerhub.grammarly.io/platform/dockerize:v0.0.1")
+	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
 	assert.Equal(t, "platform/dockerize", img.Name)
 	assert.Equal(t, "v0.0.1", img.Tag)
+	assert.True(t, img.Contains(NewFromString("dockerhub.grammarly.io/platform/dockerize:v0.0.1")))
+}
+
+func TestRangeContainsPlainVersion(t *testing.T) {
+	img := NewFromString("dockerhub.grammarly.io/platform/dockerize:0.0.1")
+	expected, _ := semver.NewRange("0.0.1")
+	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
+	assert.Equal(t, "platform/dockerize", img.Name)
+	assert.Equal(t, "0.0.1", img.Tag)
+	assert.Equal(t, expected, img.Version)
+
+	v, _ := semver.NewVersion("0.0.1")
+	assert.True(t, img.Version.Contains(v))
+}
+
+func TestUpperRangeBounds(t *testing.T) {
+	img := NewFromString("dockerhub.grammarly.io/platform/dockerize:~1.2.3")
+	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
+	assert.Equal(t, "platform/dockerize", img.Name)
+	assert.False(t, img.HasTag())
+	v, _ := semver.NewVersion("1.2.8")
+	assert.True(t, img.Version.Contains(v))
+}
+
+func TestWildcardRangeBounds(t *testing.T) {
+	img := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.*")
+	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
+	assert.Equal(t, "platform/dockerize", img.Name)
+	assert.False(t, img.HasTag())
+	v, _ := semver.NewVersion("1.2.8")
+	assert.True(t, img.Version.Contains(v))
+	v, _ = semver.NewVersion("1.2.0")
+	assert.True(t, img.Version.Contains(v))
+}
+
+func TestWildcardContains(t *testing.T) {
+	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.*")
+	img2 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.1")
+	assert.False(t, img1.HasTag())
+	assert.True(t, img1.HasVersion())
+	assert.True(t, img2.HasTag())
+	v, _ := semver.NewVersion("1.2.1")
+	assert.Equal(t, v, img2.TagAsVersion())
+
+	assert.True(t, img1.Contains(img2))
+	assert.False(t, img2.Contains(img1))
+}
+
+func TestRangeContains(t *testing.T) {
+	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:~1.2.1")
+	img2 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.999")
+	assert.True(t, img1.Contains(img2))
+	assert.False(t, img2.Contains(img1))
+}
+
+func TestNilContains(t *testing.T) {
+	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:~1.2.1")
+	assert.False(t, img1.Contains(nil))
+}
+
+func TestRangeNotContains(t *testing.T) {
+	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:~1.2.1")
+	img2 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.3.1")
+	assert.False(t, img1.Contains(img2))
+	assert.False(t, img2.Contains(img1))
+
+	img2 = NewFromString("dockerhub.grammarly.io/xxx/dockerize:1.2.1")
+	assert.False(t, img1.Contains(img2))
+
+	img2 = NewFromString("dockerhub.grammarly.com/platform/dockerize:1.2.1")
+	assert.False(t, img1.Contains(img2))
+
+	img2 = NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.1")
+	assert.True(t, img1.Contains(img2))
+}
+
+func TestVersionContains(t *testing.T) {
+	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.1")
+	img2 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.1")
+	assert.True(t, img1.Contains(img2))
+	assert.True(t, img2.Contains(img1))
+}
+
+func TestTagContains(t *testing.T) {
+	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:test1")
+	img2 := NewFromString("dockerhub.grammarly.io/platform/dockerize:test1")
+	assert.True(t, img1.Contains(img2))
+	assert.True(t, img2.Contains(img1))
+}
+
+func TestTagNotContains(t *testing.T) {
+	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:test1")
+	img2 := NewFromString("dockerhub.grammarly.io/platform/dockerize:test2")
+	assert.False(t, img1.Contains(img2))
+	assert.False(t, img2.Contains(img1))
 }
 
 func TestImageRealLifeNamingExampleWithCapi(t *testing.T) {
-	img := New("quay.io/common-api")
-	assert.Equal(t, "quay.io", img.Registry)
+	img := NewFromString("dockerhub.grammarly.io/common-api")
+	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
 	assert.Equal(t, "common-api", img.Name)
 	assert.Equal(t, "latest", img.GetTag())
 }
 
 func TestImageParsingWithNamespace(t *testing.T) {
-	img := New("hub/ns/name:1")
+	img := NewFromString("hub/ns/name:1")
 	assert.Equal(t, "hub", img.Registry)
 	assert.Equal(t, "ns/name", img.Name)
 	assert.Equal(t, "1", img.Tag)
 }
 
 func TestImageParsingWithoutTag(t *testing.T) {
-	img := New("repo/name")
+	img := NewFromString("repo/name")
 	assert.Equal(t, "", img.Registry)
 	assert.Equal(t, "repo/name", img.Name)
 	assert.Empty(t, img.Tag)
@@ -60,45 +149,45 @@ func TestImageParsingWithoutTag(t *testing.T) {
 }
 
 func TestImageLatest(t *testing.T) {
-	img := New("rocker-build:latest")
+	img := NewFromString("rocker-build:latest")
 	assert.Equal(t, "", img.Registry, "bag registry value")
 	assert.Equal(t, "rocker-build", img.Name, "bad image name")
 	assert.Equal(t, "latest", img.GetTag(), "bad image tag")
 }
 
 func TestImageIsSameKind(t *testing.T) {
-	assert.True(t, New("rocker-build").IsSameKind(*New("rocker-build")))
-	assert.True(t, New("rocker-build:latest").IsSameKind(*New("rocker-build:latest")))
-	assert.True(t, New("rocker-build").IsSameKind(*New("rocker-build:1.2.1")))
-	assert.True(t, New("rocker-build:1.2.1").IsSameKind(*New("rocker-build:1.2.1")))
-	assert.True(t, New("grammarly/rocker-build").IsSameKind(*New("grammarly/rocker-build")))
-	assert.True(t, New("grammarly/rocker-build:3.1").IsSameKind(*New("grammarly/rocker-build:3.1")))
-	assert.True(t, New("grammarly/rocker-build").IsSameKind(*New("grammarly/rocker-build:3.1")))
-	assert.True(t, New("grammarly/rocker-build:latest").IsSameKind(*New("grammarly/rocker-build:latest")))
-	assert.True(t, New("quay.io/rocker-build").IsSameKind(*New("quay.io/rocker-build")))
-	assert.True(t, New("quay.io/rocker-build:latest").IsSameKind(*New("quay.io/rocker-build:latest")))
-	assert.True(t, New("quay.io/rocker-build:3.2").IsSameKind(*New("quay.io/rocker-build:3.2")))
-	assert.True(t, New("quay.io/rocker-build").IsSameKind(*New("quay.io/rocker-build:3.2")))
-	assert.True(t, New("quay.io/grammarly/rocker-build").IsSameKind(*New("quay.io/grammarly/rocker-build")))
-	assert.True(t, New("quay.io/grammarly/rocker-build:latest").IsSameKind(*New("quay.io/grammarly/rocker-build:latest")))
-	assert.True(t, New("quay.io/grammarly/rocker-build:1.2.1").IsSameKind(*New("quay.io/grammarly/rocker-build:1.2.1")))
-	assert.True(t, New("quay.io/grammarly/rocker-build").IsSameKind(*New("quay.io/grammarly/rocker-build:1.2.1")))
+	assert.True(t, NewFromString("rocker-build").IsSameKind(*NewFromString("rocker-build")))
+	assert.True(t, NewFromString("rocker-build:latest").IsSameKind(*NewFromString("rocker-build:latest")))
+	assert.True(t, NewFromString("rocker-build").IsSameKind(*NewFromString("rocker-build:1.2.1")))
+	assert.True(t, NewFromString("rocker-build:1.2.1").IsSameKind(*NewFromString("rocker-build:1.2.1")))
+	assert.True(t, NewFromString("grammarly/rocker-build").IsSameKind(*NewFromString("grammarly/rocker-build")))
+	assert.True(t, NewFromString("grammarly/rocker-build:3.1").IsSameKind(*NewFromString("grammarly/rocker-build:3.1")))
+	assert.True(t, NewFromString("grammarly/rocker-build").IsSameKind(*NewFromString("grammarly/rocker-build:3.1")))
+	assert.True(t, NewFromString("grammarly/rocker-build:latest").IsSameKind(*NewFromString("grammarly/rocker-build:latest")))
+	assert.True(t, NewFromString("quay.io/rocker-build").IsSameKind(*NewFromString("quay.io/rocker-build")))
+	assert.True(t, NewFromString("quay.io/rocker-build:latest").IsSameKind(*NewFromString("quay.io/rocker-build:latest")))
+	assert.True(t, NewFromString("quay.io/rocker-build:3.2").IsSameKind(*NewFromString("quay.io/rocker-build:3.2")))
+	assert.True(t, NewFromString("quay.io/rocker-build").IsSameKind(*NewFromString("quay.io/rocker-build:3.2")))
+	assert.True(t, NewFromString("quay.io/grammarly/rocker-build").IsSameKind(*NewFromString("quay.io/grammarly/rocker-build")))
+	assert.True(t, NewFromString("quay.io/grammarly/rocker-build:latest").IsSameKind(*NewFromString("quay.io/grammarly/rocker-build:latest")))
+	assert.True(t, NewFromString("quay.io/grammarly/rocker-build:1.2.1").IsSameKind(*NewFromString("quay.io/grammarly/rocker-build:1.2.1")))
+	assert.True(t, NewFromString("quay.io/grammarly/rocker-build").IsSameKind(*NewFromString("quay.io/grammarly/rocker-build:1.2.1")))
 
-	assert.False(t, New("rocker-build").IsSameKind(*New("rocker-build2")))
-	assert.False(t, New("rocker-build").IsSameKind(*New("rocker-compose")))
-	assert.False(t, New("rocker-build").IsSameKind(*New("grammarly/rocker-build")))
-	assert.False(t, New("rocker-build").IsSameKind(*New("quay.io/rocker-build")))
-	assert.False(t, New("rocker-build").IsSameKind(*New("quay.io/grammarly/rocker-build")))
+	assert.False(t, NewFromString("rocker-build").IsSameKind(*NewFromString("rocker-build2")))
+	assert.False(t, NewFromString("rocker-build").IsSameKind(*NewFromString("rocker-compose")))
+	assert.False(t, NewFromString("rocker-build").IsSameKind(*NewFromString("grammarly/rocker-build")))
+	assert.False(t, NewFromString("rocker-build").IsSameKind(*NewFromString("quay.io/rocker-build")))
+	assert.False(t, NewFromString("rocker-build").IsSameKind(*NewFromString("quay.io/grammarly/rocker-build")))
 }
 
 func TestTagsGetOld(t *testing.T) {
 	tags := Tags{
 		Items: []*Tag{
-			&Tag{"1", *New("hub/ns/name:1"), time.Unix(1, 0).Unix()},
-			&Tag{"3", *New("hub/ns/name:3"), time.Unix(3, 0).Unix()},
-			&Tag{"2", *New("hub/ns/name:2"), time.Unix(2, 0).Unix()},
-			&Tag{"5", *New("hub/ns/name:5"), time.Unix(5, 0).Unix()},
-			&Tag{"4", *New("hub/ns/name:4"), time.Unix(4, 0).Unix()},
+			&Tag{"1", *NewFromString("hub/ns/name:1"), time.Unix(1, 0).Unix()},
+			&Tag{"3", *NewFromString("hub/ns/name:3"), time.Unix(3, 0).Unix()},
+			&Tag{"2", *NewFromString("hub/ns/name:2"), time.Unix(2, 0).Unix()},
+			&Tag{"5", *NewFromString("hub/ns/name:5"), time.Unix(5, 0).Unix()},
+			&Tag{"4", *NewFromString("hub/ns/name:4"), time.Unix(4, 0).Unix()},
 		},
 	}
 	old := tags.GetOld(2)

--- a/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename_test.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename_test.go
@@ -130,7 +130,7 @@ func TestImageRealLifeNamingExampleWithCapi(t *testing.T) {
 	img := NewFromString("dockerhub.grammarly.io/common-api")
 	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
 	assert.Equal(t, "common-api", img.Name)
-	assert.Equal(t, "latest", img.GetTag())
+	assert.Equal(t, "", img.GetTag())
 }
 
 func TestImageParsingWithNamespace(t *testing.T) {
@@ -145,7 +145,7 @@ func TestImageParsingWithoutTag(t *testing.T) {
 	assert.Equal(t, "", img.Registry)
 	assert.Equal(t, "repo/name", img.Name)
 	assert.Empty(t, img.Tag)
-	assert.Equal(t, "latest", img.GetTag())
+	assert.Equal(t, "", img.GetTag())
 }
 
 func TestImageLatest(t *testing.T) {

--- a/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename_test.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/imagename/imagename_test.go
@@ -48,7 +48,7 @@ func TestUpperRangeBounds(t *testing.T) {
 	img := NewFromString("dockerhub.grammarly.io/platform/dockerize:~1.2.3")
 	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
 	assert.Equal(t, "platform/dockerize", img.Name)
-	assert.False(t, img.HasTag())
+	assert.False(t, img.IsStrict())
 	v, _ := semver.NewVersion("1.2.8")
 	assert.True(t, img.Version.Contains(v))
 }
@@ -57,7 +57,7 @@ func TestWildcardRangeBounds(t *testing.T) {
 	img := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.*")
 	assert.Equal(t, "dockerhub.grammarly.io", img.Registry)
 	assert.Equal(t, "platform/dockerize", img.Name)
-	assert.False(t, img.HasTag())
+	assert.False(t, img.IsStrict())
 	v, _ := semver.NewVersion("1.2.8")
 	assert.True(t, img.Version.Contains(v))
 	v, _ = semver.NewVersion("1.2.0")
@@ -67,9 +67,9 @@ func TestWildcardRangeBounds(t *testing.T) {
 func TestWildcardContains(t *testing.T) {
 	img1 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.*")
 	img2 := NewFromString("dockerhub.grammarly.io/platform/dockerize:1.2.1")
-	assert.False(t, img1.HasTag())
-	assert.True(t, img1.HasVersion())
-	assert.True(t, img2.HasTag())
+	assert.False(t, img1.IsStrict())
+	assert.True(t, img1.HasVersionRange())
+	assert.True(t, img2.IsStrict())
 	v, _ := semver.NewVersion("1.2.1")
 	assert.Equal(t, v, img2.TagAsVersion())
 

--- a/vendor/src/github.com/wmark/semver/LICENSE
+++ b/vendor/src/github.com/wmark/semver/LICENSE
@@ -1,0 +1,68 @@
+Copyright © 2014 Mark Kubacki.
+All rights reserved.
+
+"You" or "Your" means an individual or a legal entity exercising rights
+under this license. For legal entities, "You" or "Your" includes any
+entity which controls, is controlled by, or is under common control with,
+You, where "control" means (a) the power, direct or indirect, to cause
+the direction or management of such entity, whether by contract or
+otherwise, or (b) ownership of fifty percent (50%) or more of the
+outstanding shares or beneficial ownership of such entity.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+   * Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+   * This license will not be construed as creating an agency,
+partnership, joint venture, or any other form of legal association
+between or among You, the copyright holder, or any contributor, and
+You will not represent to the contrary, whether expressly, by
+implication, appearance, or otherwise.
+
+   * You do not conduct, endorse, promote, assist in or authorize
+offenses against privacy. Nor do you train how to do so, or create,
+alter, install, maintain or operate tools with the effect of, intention
+to or designed for the purpose of decreasing privacy, with the exception
+of a communication you are a sender or receiver thereof, or overtly
+monitoring your own premises, or to the absolute unavoidable minimum if
+being a service provider for the sender or receiver and having a specific
+prior written permission of the sender or receiver.
+     Offenses against privacy are, but not limited to:
+   - mass surveillance, "dragnet" surveillance, warrantless wiretapping,
+     wiretapping for preventive purposes, monitoring or interception
+     of communication
+   - collection of communication metadata, collection of or accessing
+   stored communication, obtaining communications information,
+   - tampering with private communications,
+   - decryption of messages,
+   - aural transfer,
+   - or storing, transmitting or accessing metadata and/or messages
+   obtained by a means decreasing and/or offending privacy as expressed
+   above.
+This even applies to telephonic, wired and electronic communication,
+including stored messages, even if no reasonable expection of privacy
+can be assumed, and even if it is deemed being "lawful" to do so.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/src/github.com/wmark/semver/README.md
+++ b/vendor/src/github.com/wmark/semver/README.md
@@ -1,0 +1,86 @@
+Semantic Versioning for Golang
+==============================
+
+[![Build Status](https://drone.io/github.com/wmark/semver/status.png)](https://drone.io/github.com/wmark/semver/latest)
+[![Coverage Status](https://coveralls.io/repos/wmark/semver/badge.png?branch=master)](https://coveralls.io/r/wmark/semver?branch=master)
+[![GoDoc](https://godoc.org/github.com/wmark/semver?status.png)](https://godoc.org/github.com/wmark/semver)
+
+A library for parsing and processing of *Versions* and *Ranges* in:
+
+* [Semantic Versioning](http://semver.org/) (semver) v2.0.0 notation
+  * used by npmjs.org, pypi.org…
+* Gentoo's ebuild format
+* NPM
+
+Licensed under a [BSD-style license](LICENSE).
+
+Usage
+-----
+```bash
+$ go get -v github.com/wmark/semver
+```
+
+```go
+import github.com/wmark/semver
+
+v1, err := semver.NewVersion("1.2.3-beta")
+v2, err := semver.NewVersion("2.0.0-alpha20140805.456-rc3+build1800")
+v1.Less(v2)
+
+r1, err := NewRange("~1.2")
+r1.Contains(v1)      // true
+r1.IsSatisfiedBy(v1) // false
+```
+
+Also check the [GoDocs](http://godoc.org/github.com/wmark/semver)
+and [Gentoo Linux Ebuild File Format](http://devmanual.gentoo.org/ebuild-writing/file-format/),
+[Gentoo's notation of dependencies](http://devmanual.gentoo.org/general-concepts/dependencies/).
+
+Please Note
+-----------
+
+It is, ordered from lowest to highest:
+
+    alpha < beta < pre < rc < (no release type/»common«) < p
+
+Therefore it is:
+
+    Version("1.0.0-pre1") ≙ Version("1.0.0-1") < Version("1.0.0") < Version("1.0.0-p1")
+
+… because the SemVer specification says:
+
+    9. A pre-release version MAY be denoted by appending a hyphen and a series of
+    dot separated identifiers immediately following the patch version. […]
+
+Most *NodeJS* authors write **~1.2.3** where **>=1.2.3** would fit better.
+*~1.2.3* is ```Range(">=1.2.3 <1.3.0")``` and excludes versions such as *1.4.0*,
+which almost always work.
+
+Contribute
+----------
+
+Please open issues with minimal examples of what is going wrong. For example:
+
+    Mark, this does not work but I feel that it should:
+    ```golang
+    v, err := semver.Version("17.1o0")
+    # yields an error
+    # I expected 17.100
+    ```
+
+Please write a test case with your expectations, if you ask for a new feature.
+
+    I'd like **semver.Range** to support interface **expvar.Var**, like this:
+    ```golang
+    Convey("Range implements interface's expvar.Var…", t, func() {
+      r, _ := NewRange("1.2.3")
+      
+      Convey("String()", func() {
+        So(r.String(), ShouldEqual, "1.2.3")
+      })
+    })
+    ```
+
+Pull requests are welcome.
+Please add your name and email address to file *AUTHORS* and/or *CONTRIBUTORS*.
+Thanks!

--- a/vendor/src/github.com/wmark/semver/range.go
+++ b/vendor/src/github.com/wmark/semver/range.go
@@ -1,0 +1,196 @@
+// Copyright 2014 The Semver Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package semver
+
+import (
+	"errors"
+	"strings"
+)
+
+type Range struct {
+	lower       *Version
+	equalsLower bool
+	upper       *Version
+	equalsUpper bool
+}
+
+func NewRange(str string) (*Range, error) {
+	if str == "*" || str == "x" || str == "" {
+		// an empty Range contains everything
+		return new(Range), nil
+	}
+	if strings.HasSuffix(str, ".x") || strings.HasSuffix(str, ".*") {
+		str = strings.TrimRight(str, ".x*")
+	}
+	if str[0] == '^' || str[0] == '~' {
+		return newRangeByShortcut(str)
+	}
+
+	isNaturalRange := strings.ContainsAny(str, " –")
+	if !isNaturalRange {
+		switch strings.Count(str, ".") {
+		case 1:
+			return newRangeByShortcut("~" + str)
+		case 0:
+			return newRangeByShortcut("^" + str)
+		}
+	}
+
+	vr := new(Range)
+	if !isNaturalRange {
+		err := vr.setBound(str)
+		return vr, err
+	}
+
+	for _, delimiter := range []string{" - ", " – ", "–", " "} {
+		if strings.Contains(str, delimiter) {
+			parts := strings.Split(str, delimiter)
+			if len(parts) == 2 {
+				if parts[0][0] == '>' {
+					vr.setBound(parts[0])
+				} else {
+					vr.setBound(">=" + parts[0])
+				}
+				if parts[1][0] == '<' {
+					vr.setBound(parts[1])
+				} else {
+					vr.setBound("<=" + parts[1])
+				}
+				return vr, nil
+			} else {
+				return nil, errors.New("Range contains more than two elements.")
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func (r *Range) setBound(str string) error {
+	t := strings.TrimLeft(str, "~=v<>^")
+	num, err := NewVersion(t)
+	if err != nil {
+		return err
+	}
+
+	equalOk := strings.Contains(str, "=")
+	if !strings.Contains(str, ">") {
+		r.equalsUpper = equalOk
+		r.upper = num
+	}
+	if !strings.Contains(str, "<") {
+		r.equalsLower = equalOk
+		r.lower = num
+	}
+
+	return nil
+}
+
+func newRangeByShortcut(str string) (*Range, error) {
+	t := strings.TrimLeft(str, "~^")
+	num, err := NewVersion(t)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(t, "0.0.") {
+		return NewRange(t)
+	}
+
+	r := new(Range)
+	r.lower = num
+	r.equalsLower = true
+	r.upper = new(Version)
+
+	switch {
+	case strings.HasPrefix(t, "0."):
+		r.upper.version[0] = r.lower.version[0]
+		r.upper.version[1] = r.lower.version[1] + 1
+	case str[0] == '^' || !strings.ContainsAny(t, "."):
+		r.upper.version[0] = r.lower.version[0] + 1
+	case str[0] == '~':
+		r.upper.version[0] = r.lower.version[0]
+		r.upper.version[1] = r.lower.version[1] + 1
+	default:
+		return nil, errors.New("Unsupported shortcut notation for Range.")
+	}
+
+	return r, nil
+}
+
+// Checks if a Version falls into a Range.
+func (r *Range) Contains(v *Version) bool {
+	if v == nil {
+		return false
+	}
+
+	if r.upper == r.lower {
+		return r.lower.LimitedEqual(v)
+	}
+
+	return r.satisfiesLowerBound(v) && r.satisfiesUpperBound(v)
+}
+
+// Works like Contains, but rejects pre-releases if neither of the bounds is a pre-release.
+// Use this in the context of pulling in packages because it follows the spirit of §9 SemVer.
+// Also see https://github.com/npm/node-semver/issues/64
+func (r *Range) IsSatisfiedBy(v *Version) bool {
+	if !r.Contains(v) {
+		return false
+	}
+	if v.IsAPreRelease() {
+		if r.lower != nil && r.lower.IsAPreRelease() && r.lower.sharesPrefixWith(v) {
+			return true
+		}
+		if r.upper != nil && r.upper.IsAPreRelease() && r.upper.sharesPrefixWith(v) {
+			return true
+		}
+		return false
+	}
+	return true
+}
+
+func (r *Range) satisfiesLowerBound(v *Version) bool {
+	if r.lower == nil {
+		return true
+	}
+
+	equal := r.lower.LimitedEqual(v)
+	if r.equalsLower && equal {
+		return true
+	}
+
+	return r.lower.limitedLess(v) && !equal
+}
+
+func (r *Range) satisfiesUpperBound(v *Version) bool {
+	if r.upper == nil {
+		return true
+	}
+
+	equal := r.upper.LimitedEqual(v)
+	if r.equalsUpper && equal {
+		return true
+	}
+
+	if !r.equalsUpper && r.upper.version[idxReleaseType] == common {
+		equal = r.upper.sharesPrefixWith(v)
+	}
+
+	return v.limitedLess(r.upper) && !equal
+}
+
+// Convenience function for former NodeJS developers.
+func Satisfies(aVersion, aRange string) (bool, error) {
+	v, err := NewVersion(aVersion)
+	if err != nil {
+		return false, err
+	}
+	r, err := NewRange(aRange)
+	if err != nil {
+		return false, err
+	}
+
+	return r.IsSatisfiedBy(v), nil
+}

--- a/vendor/src/github.com/wmark/semver/range_test.go
+++ b/vendor/src/github.com/wmark/semver/range_test.go
@@ -1,0 +1,610 @@
+// Copyright 2014 The Semver Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package semver
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func hasLowerBound(aRange interface{}, aVersion ...interface{}) string {
+	a := aRange.(*Range)
+	if s := ShouldResemble(a.lower, aVersion[0]); s != "" {
+		return s
+	}
+	return ShouldBeTrue(a.equalsLower)
+}
+
+func isLeftClosedBy(aRange interface{}, aVersion ...interface{}) string {
+	a := aRange.(*Range)
+	if s := ShouldResemble(a.lower, aVersion[0]); s != "" {
+		return s
+	}
+	return ShouldBeFalse(a.equalsLower)
+}
+
+func hasUpperBound(aRange interface{}, aVersion ...interface{}) string {
+	a := aRange.(*Range)
+	if s := ShouldResemble(a.upper, aVersion[0]); s != "" {
+		return s
+	}
+	return ShouldBeTrue(a.equalsUpper)
+}
+
+func isRightClosedBy(aRange interface{}, aVersion ...interface{}) string {
+	a := aRange.(*Range)
+	if s := ShouldResemble(a.upper, aVersion[0]); s != "" {
+		return s
+	}
+	return ShouldBeFalse(a.equalsUpper)
+}
+
+func testIfResembles(actual, expected *Range) {
+	So(actual.lower, ShouldResemble, expected.lower)
+	So(actual.equalsLower, ShouldEqual, expected.equalsLower)
+	So(actual.upper, ShouldResemble, expected.upper)
+	So(actual.equalsUpper, ShouldEqual, expected.equalsUpper)
+}
+
+func shouldContain(aRange interface{}, aVersion ...interface{}) string {
+	a := aRange.(*Range)
+	for _, version := range aVersion {
+		v := version.(string)
+		ver, err := NewVersion(v)
+		if err != nil {
+			return err.Error()
+		}
+		if s := ShouldBeTrue(a.Contains(ver)); s != "" {
+			return v + " is not in Range"
+		}
+	}
+	return ""
+}
+
+func shouldNotContain(aRange interface{}, aVersion ...interface{}) string {
+	a := aRange.(*Range)
+	for _, version := range aVersion {
+		v := version.(string)
+		ver, err := NewVersion(v)
+		if err != nil {
+			return err.Error()
+		}
+		if s := ShouldBeFalse(a.Contains(ver)); s != "" {
+			return v + " is in Range"
+		}
+	}
+	return ""
+}
+
+func TestRangeConstruction(t *testing.T) {
+
+	Convey("version 1.2.3 should be part of…", t, func() {
+		ver, _ := NewVersion("1.2.3")
+
+		Convey("specific Range 1.2.3", func() {
+			verRange, _ := NewRange("1.2.3")
+			So(verRange.lower, ShouldResemble, ver)
+		})
+	})
+
+	v100, _ := NewVersion("1.0.0")
+	v120, _ := NewVersion("1.2.0")
+	v123, _ := NewVersion("1.2.3")
+	v130, _ := NewVersion("1.3.0")
+	v200, _ := NewVersion("2.0.0")
+
+	Convey("Range >=1.2.3 <=1.3.0…", t, func() {
+		verRange, err := NewRange(">=1.2.3 <=1.3.0")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >=1.2.3", func() {
+			So(verRange, hasLowerBound, v123)
+		})
+
+		Convey("has upper bound <=1.3.0", func() {
+			So(verRange, hasUpperBound, v130)
+		})
+	})
+
+	Convey("Range >1.2.3 <1.3.0…", t, func() {
+		verRange, err := NewRange(">1.2.3 <1.3.0")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >1.2.3", func() {
+			So(verRange, isLeftClosedBy, v123)
+		})
+
+		Convey("has upper bound <1.3.0", func() {
+			So(verRange, isRightClosedBy, v130)
+		})
+	})
+
+	Convey("Range 1.2.3 - 1.3.0…", t, func() {
+		verRange, err := NewRange("1.2.3 - 1.3.0")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >=1.2.3", func() {
+			So(verRange, hasLowerBound, v123)
+		})
+
+		Convey("has upper bound <=1.3.0", func() {
+			So(verRange, hasUpperBound, v130)
+		})
+	})
+
+	Convey("Range ~1.2.3 equals: >=1.2.3 <1.3.0", t, func() {
+		verRange, err := NewRange("~1.2.3")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >=1.2.3", func() {
+			So(verRange, hasLowerBound, v123)
+		})
+
+		Convey("has upper bound <1.3.0", func() {
+			So(verRange, isRightClosedBy, v130)
+		})
+	})
+
+	Convey("Range ^1.2.3 equals: >=1.2.3 <2.0.0", t, func() {
+		verRange, err := NewRange("^1.2.3")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >=1.2.3", func() {
+			So(verRange, hasLowerBound, v123)
+		})
+
+		Convey("has upper bound <2.0.0", func() {
+			So(verRange, isRightClosedBy, v200)
+		})
+	})
+
+	Convey("Range ~1.2 equals: >=1.2.0 <1.3.0", t, func() {
+		verRange, err := NewRange("~1.2")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >=1.2.0", func() {
+			So(verRange, hasLowerBound, v120)
+		})
+
+		Convey("has upper bound <1.3.0", func() {
+			So(verRange, isRightClosedBy, v130)
+		})
+	})
+
+	Convey("Range ^1.2 equals: >=1.2.0 <2.0.0", t, func() {
+		verRange, err := NewRange("^1.2")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >=1.2.0", func() {
+			So(verRange, hasLowerBound, v120)
+		})
+
+		Convey("has upper bound <2.0.0", func() {
+			So(verRange, isRightClosedBy, v200)
+		})
+	})
+
+	Convey("Ranges ^1 and ~1 equal: >=1.0.0 <2.0.0", t, func() {
+		r1, err := NewRange("^1")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+		r2, err := NewRange("^1")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+
+		Convey("has lower bound >=1.0.0", func() {
+			So(r1, hasLowerBound, v100)
+			So(r2, hasLowerBound, v100)
+		})
+
+		Convey("has upper bound <2.0.0", func() {
+			So(r1, isRightClosedBy, v200)
+			So(r2, isRightClosedBy, v200)
+		})
+	})
+
+	Convey("Given .x and .* notations", t, func() {
+		refRange, _ := NewRange("^1")
+
+		Convey("1.x equals ^1", func() {
+			r1, err := NewRange("1.x")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, refRange)
+		})
+
+		Convey("1.* equals ^1", func() {
+			r1, err := NewRange("1.*")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, refRange)
+		})
+
+		Convey("1 equals ^1", func() {
+			r1, err := NewRange("1")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, refRange)
+		})
+
+		smallRange, _ := NewRange("~1.2")
+
+		Convey("1.2.x equals ~1.2", func() {
+			r1, err := NewRange("1.2.x")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, smallRange)
+		})
+
+		Convey("1.2.* equals ~1.2", func() {
+			r1, err := NewRange("1.2.*")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, smallRange)
+		})
+
+		Convey("1.2 equals ~1.2", func() {
+			r1, err := NewRange("1.2")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, smallRange)
+		})
+	})
+
+	Convey("Notations for 'any'", t, func() {
+		refRange := new(Range)
+
+		Convey("'x'", func() {
+			r1, err := NewRange("x")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, refRange)
+		})
+
+		Convey("'*'", func() {
+			r1, err := NewRange("*")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, refRange)
+		})
+
+		Convey("'' (empty string)", func() {
+			r1, err := NewRange("")
+			So(err, ShouldBeNil)
+			if err != nil {
+				return
+			}
+			testIfResembles(r1, refRange)
+		})
+	})
+
+	// now come fringe cases
+	Convey("Range ^0.1.3 and ~0.1.3 equal: >=0.1.3 <0.2.0", t, func() {
+		r1, err := NewRange("^0.1.3")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+		r2, err := NewRange("~0.1.3")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+		v013, _ := NewVersion("0.1.3")
+		v020, _ := NewVersion("0.2.0")
+
+		Convey("have lower bound >=0.1.3", func() {
+			So(r1, hasLowerBound, v013)
+			So(r2, hasLowerBound, v013)
+		})
+
+		Convey("have upper bound <0.2.0", func() {
+			So(r1, isRightClosedBy, v020)
+			So(r2, isRightClosedBy, v020)
+		})
+	})
+
+	Convey("Range ^0.0.2 and ~0.0.2 are 0.2.0", t, func() {
+		r1, err := NewRange("^0.0.2")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+		r2, err := NewRange("~0.0.2")
+		So(err, ShouldBeNil)
+		if err != nil {
+			return
+		}
+		r002, _ := NewRange("0.0.2")
+
+		Convey("have the same bounds as 0.2.0", func() {
+			testIfResembles(r1, r002)
+			testIfResembles(r2, r002)
+		})
+	})
+}
+
+func TestSingleBound(t *testing.T) {
+
+	Convey("Given a specific version as Range…", t, func() {
+		Convey("1.2.3…", func() {
+			verRange, _ := NewRange("1.2.3")
+
+			Convey("reject Version 1.2.4", func() {
+				So(verRange, shouldNotContain, "1.2.4")
+			})
+
+			Convey("accept Version 1.2.3", func() {
+				So(verRange, shouldContain, "1.2.3")
+			})
+
+			Convey("accept Version 1.2.3+build2014 (ignore build)", func() {
+				So(verRange, shouldContain, "1.2.3+build2014")
+			})
+
+			Convey("accept Version 1.2.3-p1 (patch levels are reasonably equal)", func() {
+				So(verRange, shouldContain, "1.2.3-p1")
+			})
+
+			Convey("reject pre-releases like 1.2.3-alpha", func() {
+				So(verRange, shouldNotContain, "1.2.3-alpha")
+			})
+		})
+
+		Convey("1.2.3-alpha20…", func() {
+			verRange, _ := NewRange("1.2.3-alpha20")
+
+			Convey("accept Version 1.2.3-alpha20", func() {
+				So(verRange, shouldContain, "1.2.3-alpha20")
+			})
+			Convey("reject Version 1.2.3-alpha5", func() {
+				So(verRange, shouldNotContain, "1.2.3-alpha5")
+			})
+			Convey("reject Version 1.2.3-beta", func() {
+				So(verRange, shouldNotContain, "1.2.3-beta")
+			})
+			Convey("reject Version 1.2.3", func() {
+				So(verRange, shouldNotContain, "1.2.3")
+			})
+		})
+	})
+
+	Convey("Given the lower bound >1.2.3", t, func() {
+		verRange, _ := NewRange(">1.2.3")
+
+		Convey("reject Version 1.2.3", func() {
+			So(verRange, shouldNotContain, "1.2.3")
+		})
+
+		Convey("reject Version 1.2.3-p1 (ignore release/pre-release)", func() {
+			So(verRange, shouldNotContain, "1.2.3-p1")
+		})
+
+		Convey("reject Version 1.2.3+build2014 (ignore build)", func() {
+			So(verRange, shouldNotContain, "1.2.3+build2014")
+		})
+
+		Convey("accept Versions…", func() {
+			Convey("1.2.4", func() {
+				So(verRange, shouldContain, "1.2.4")
+			})
+			Convey("1.3.0", func() {
+				So(verRange, shouldContain, "1.3.0")
+			})
+			Convey("2.0.0", func() {
+				So(verRange, shouldContain, "2.0.0")
+			})
+		})
+	})
+
+	Convey("A lower bound >=1.2.3…", t, func() {
+		verRange, _ := NewRange(">=1.2.3")
+
+		Convey("should contain Version 1.2.3", func() {
+			So(verRange, shouldContain, "1.2.3")
+		})
+
+		Convey("should contain Version 1.2.3-p1", func() {
+			So(verRange, shouldContain, "1.2.3-p1")
+		})
+
+		Convey("but NOT contain 1.2.3-rc (exclude pre-release)", func() {
+			So(verRange, shouldNotContain, "1.2.3-rc")
+		})
+	})
+
+	Convey("Over-specific lower bounds >=1.2.3-alpha4…", t, func() {
+		verRange, _ := NewRange(">=1.2.3-alpha4")
+
+		Convey("should contain Version 1.2.4", func() {
+			So(verRange, shouldContain, "1.2.4")
+		})
+
+		Convey("should contain Version 1.2.3-alpha4", func() {
+			So(verRange, shouldContain, "1.2.3-alpha4")
+		})
+
+		Convey("but NOT contain 1.2.3-alpha", func() {
+			So(verRange, shouldNotContain, "1.2.3-alpha")
+		})
+	})
+
+	Convey("Upper bounds such as <1.2.3…", t, func() {
+		verRange, _ := NewRange("<1.2.3")
+
+		Convey("reject Version 1.2.3", func() {
+			So(verRange, shouldNotContain, "1.2.3")
+		})
+
+		Convey("reject Version 1.2.3-alpha3 (ignore release/pre-release)", func() {
+			So(verRange, shouldNotContain, "1.2.3-alpha3")
+		})
+
+		Convey("reject Version 1.2.3+build2014 (ignore build)", func() {
+			So(verRange, shouldNotContain, "1.2.3+build2014")
+		})
+
+		Convey("accept Versions…", func() {
+			Convey("1.2.0", func() {
+				So(verRange, shouldContain, "1.2.0")
+			})
+			Convey("1.1.0", func() {
+				So(verRange, shouldContain, "1.1.0")
+			})
+			Convey("1.0.0", func() {
+				So(verRange, shouldContain, "1.0.0")
+			})
+		})
+	})
+
+	Convey("An over-specific upper bound <1.2.3-beta20…", t, func() {
+		verRange, _ := NewRange("<1.2.3-beta20")
+
+		Convey("reject Version 1.2.3-beta20", func() {
+			So(verRange, shouldNotContain, "1.2.3-beta20")
+		})
+
+		Convey("reject Version 1.2.3-beta20-alpha3 (ignore release specifier)", func() {
+			So(verRange, shouldNotContain, "1.2.3-beta20-alpha3")
+		})
+
+		Convey("reject Version 1.2.3-beta20+build2014 (ignore build)", func() {
+			So(verRange, shouldNotContain, "1.2.3-beta20+build2014")
+		})
+
+		Convey("accept Versions…", func() {
+			Convey("1.2.3-beta19", func() {
+				So(verRange, shouldContain, "1.2.3-beta19")
+			})
+			Convey("1.2.3-alpha", func() {
+				So(verRange, shouldContain, "1.2.3-alpha")
+			})
+			Convey("1.2.0", func() {
+				So(verRange, shouldContain, "1.2.0")
+			})
+		})
+	})
+
+	Convey("An upper bound with equality <=1.2.3…", t, func() {
+		verRange, _ := NewRange("<=1.2.3")
+
+		Convey("should contain Version 1.2.3", func() {
+			So(verRange, shouldContain, "1.2.3")
+		})
+
+		Convey("should contain Version 1.2.3-p1", func() {
+			So(verRange, shouldContain, "1.2.3-p1")
+		})
+
+		Convey("and, that's new, contain 1.2.3-rc (INCLUDE pre-release)", func() {
+			So(verRange, shouldContain, "1.2.3-rc")
+		})
+	})
+
+}
+
+func TestSatisfies(t *testing.T) {
+
+	Convey("Convenience function 'Satisfies'", t, func() {
+
+		Convey("works with valid input", func() {
+			t, _ := Satisfies("1.2.3", "^1.2.2")
+			So(t, ShouldBeTrue)
+			t, _ = Satisfies("1.2.3-2", "^1.2.3-1")
+			So(t, ShouldBeTrue)
+		})
+
+		Convey("yields an error on invalid Version", func() {
+			t, err := Satisfies("1.2.3.4.5.6", "^1.2.2")
+			So(t, ShouldBeFalse)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("yields an error on invalid Range", func() {
+			t, err := Satisfies("1.2.3", "^1.2.2/1.2.5")
+			So(t, ShouldBeFalse)
+			So(err, ShouldNotBeNil)
+		})
+	})
+
+	Convey("Range.IsSatisfiedBy…", t, func() {
+
+		Convey("rejects pre-releases", func() {
+			t, _ := Satisfies("1.2.3-1", "^1.2.2")
+			So(t, ShouldBeFalse)
+			t, _ = Satisfies("1.2.4-1", "^1.2.2-1")
+			So(t, ShouldBeFalse)
+			t, _ = Satisfies("1.2.3-1", "<1.2.3")
+			So(t, ShouldBeFalse)
+		})
+
+		Convey("accepts pre-releases for a pre-release upper bound with the same prefix", func() {
+			t, _ := Satisfies("1.2.3-1", "<1.2.3-1")
+			So(t, ShouldBeFalse)
+			t, _ = Satisfies("1.2.3-1", "<1.2.3-2")
+			So(t, ShouldBeTrue)
+			t, _ = Satisfies("1.2.3-1", "<=1.2.3-1")
+			So(t, ShouldBeTrue)
+		})
+
+		Convey("accepts pre-releases for a pre-release lower bound with the same prefix", func() {
+			t, _ := Satisfies("1.2.3-1", ">1.2.3-1")
+			So(t, ShouldBeFalse)
+			t, _ = Satisfies("1.2.3-2", ">1.2.3-1")
+			So(t, ShouldBeTrue)
+			t, _ = Satisfies("1.2.3-1", ">=1.2.3-1")
+			So(t, ShouldBeTrue)
+		})
+	})
+
+	Convey("Test the examples found in README file.", t, func() {
+		v, _ := NewVersion("1.2.3-beta")
+		r, _ := NewRange("~1.2")
+		So(r.Contains(v), ShouldBeTrue)
+		So(r.IsSatisfiedBy(v), ShouldBeFalse)
+	})
+}

--- a/vendor/src/github.com/wmark/semver/semver.go
+++ b/vendor/src/github.com/wmark/semver/semver.go
@@ -1,0 +1,173 @@
+// Copyright 2014 The Semver Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package semver
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type dotDelimitedNumber []int
+
+func newDotDelimitedNumber(str string) (dotDelimitedNumber, error) {
+	strSequence := strings.Split(str, ".")
+	if len(strSequence) > 4 {
+		return nil, errors.New("too much columns on that number")
+	}
+	numSequence := make(dotDelimitedNumber, 0, len(strSequence))
+	for _, s := range strSequence {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return numSequence, err
+		}
+		numSequence = append(numSequence, i)
+	}
+	return numSequence, nil
+}
+
+// alpha = -4, beta = -3, pre = -2, rc = -1, common = 0, patch = 1
+const (
+	alpha = iota - 4
+	beta
+	pre
+	rc
+	common
+	patch
+)
+
+const (
+	idxReleaseType   = 4
+	idxRelease       = 5
+	idxSpecifierType = 9
+	idxSpecifier     = 10
+)
+
+var releaseDesc = map[int]string{
+	alpha: "alpha",
+	beta:  "beta",
+	pre:   "pre",
+	rc:    "rc",
+	patch: "p",
+}
+
+var releaseValue = map[string]int{
+	"alpha": alpha,
+	"beta":  beta,
+	"pre":   pre,
+	"":      pre,
+	"rc":    rc,
+	"p":     patch,
+}
+
+var verRegexp = regexp.MustCompile(`^(\d+(?:\.\d+){0,3})(?:([-_]alpha|[-_]beta|[-_]pre|[-_]rc|[-_]p|-)(\d+(?:\.\d+){0,3})?)?(?:([-_]alpha|[-_]beta|[-_]pre|[-_]rc|[-_]p|-)(\d+(?:\.\d+){0,3})?)?(?:(\+build)(\d*))?$`)
+
+type Version struct {
+	// 0–3: version, 4: releaseType, 5–8: releaseVer, 9: releaseSpecifier, 10–14: specifier
+	version [14]int
+	build   int
+}
+
+func NewVersion(str string) (*Version, error) {
+	allMatches := verRegexp.FindAllStringSubmatch(str, -1)
+	if allMatches == nil {
+		return nil, errors.New("Given string does not resemble a Version.")
+	}
+	ver := new(Version)
+	m := allMatches[0]
+
+	// version
+	n, err := newDotDelimitedNumber(m[1])
+	if err != nil {
+		return nil, err
+	}
+	copy(ver.version[:], n)
+
+	// release
+	if m[2] != "" {
+		ver.version[idxReleaseType] = releaseValue[strings.Trim(m[2], "-_")]
+	}
+	if m[3] != "" {
+		n, err := newDotDelimitedNumber(m[3])
+		if err != nil {
+			return nil, err
+		}
+		copy(ver.version[idxRelease:], n)
+	}
+
+	// release specifier
+	if m[4] != "" {
+		ver.version[idxSpecifierType] = releaseValue[strings.Trim(m[4], "-_")]
+	}
+	if m[5] != "" {
+		n, err := newDotDelimitedNumber(m[5])
+		if err != nil {
+			return nil, err
+		}
+		copy(ver.version[idxSpecifier:], n)
+	}
+
+	// build
+	if m[7] != "" {
+		i, err := strconv.Atoi(m[7])
+		if err != nil {
+			return nil, err
+		}
+		ver.build = i
+	}
+
+	return ver, nil
+}
+
+// Returns sign(a - b).
+func signDelta(a, b [14]int, cutoffIdx int) int8 {
+	for i := range a {
+		if i >= cutoffIdx {
+			return 0
+		}
+		if a[i] < b[i] {
+			return -1
+		} else if a[i] > b[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// Convenience function for sorting.
+func (t *Version) Less(o *Version) bool {
+	sd := signDelta(t.version, o.version, 15)
+	return sd < 0 || (sd == 0 && t.build < o.build)
+}
+
+// Limited to version, (pre-)release type and (pre-)release version.
+// Commutative.
+func (t *Version) limitedLess(o *Version) bool {
+	return signDelta(t.version, o.version, idxSpecifierType) < 0
+}
+
+// Equality limited to version, (pre-)release type and (pre-)release version.
+// For example, 1.0.0-pre and 1.0.0-rc are not the same, but
+// 1.0.0-beta-pre3 and 1.0.0-beta-pre5 are equal.
+// Permits 'patch levels', regarding 1.0.0 equal to 1.0.0-p1.
+// Non-commutative: 1.0.0-p1 does not equal 1.0.0!
+func (t *Version) LimitedEqual(o *Version) bool {
+	if t.version[idxReleaseType] == common && o.version[idxReleaseType] > common {
+		return t.sharesPrefixWith(o)
+	}
+	return signDelta(t.version, o.version, idxSpecifierType) == 0
+}
+
+// Use this to exclude pre-releases.
+func (v *Version) IsAPreRelease() bool {
+	return v.version[idxReleaseType] < common
+}
+
+// A 'prefix' is the major, minor, patch and revision number.
+// For example: 1.2.3.4…
+func (t *Version) sharesPrefixWith(o *Version) bool {
+	return signDelta(t.version, o.version, idxReleaseType) == 0
+}

--- a/vendor/src/github.com/wmark/semver/semver_test.go
+++ b/vendor/src/github.com/wmark/semver/semver_test.go
@@ -1,0 +1,251 @@
+// Copyright 2014 The Semver Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package semver
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDotDelimitedNumber(t *testing.T) {
+	goodVer := "1.3.8"
+	badVer := "a.b.c"
+
+	Convey("Given an acceptable Version string", t, func() {
+		v, err := newDotDelimitedNumber(goodVer)
+
+		Convey("convert it correctly", func() {
+			So(err, ShouldBeNil)
+			So(len(v), ShouldEqual, 3)
+			So(v, ShouldResemble, dotDelimitedNumber([]int{1, 3, 8}))
+		})
+	})
+
+	Convey("Given a mal-formed Version string", t, func() {
+		v, err := newDotDelimitedNumber(badVer)
+
+		Convey("yield an error", func() {
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("return an incomplete sequence", func() {
+			So(len(v), ShouldBeLessThan, 3)
+		})
+	})
+}
+
+func TestVersion(t *testing.T) {
+	Convey("Version 1.3.8 should be part of Version…", t, func() {
+		v := []int{1, 3, 8, 0}
+
+		Convey("1.3.8", func() {
+			refVer, err := NewVersion("1.3.8")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+		Convey("1.3.8+build20140722", func() {
+			refVer, err := NewVersion("1.3.8+build20140722")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+		Convey("1.3.8+build2014", func() {
+			refVer, err := NewVersion("1.3.8+build2014")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+		Convey("1.3.8-alpha", func() {
+			refVer, err := NewVersion("1.3.8-alpha")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+		Convey("1.3.8-beta", func() {
+			refVer, err := NewVersion("1.3.8-beta")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+		Convey("1.3.8-pre", func() {
+			refVer, err := NewVersion("1.3.8-pre")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+		Convey("1.3.8-r3", func() {
+			refVer, err := NewVersion("1.3.8-p3")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+		Convey("1.3.8-3", func() {
+			refVer, err := NewVersion("1.3.8-3")
+			So(err, ShouldBeNil)
+			So(refVer.version[:4], ShouldResemble, v)
+		})
+
+	})
+
+	Convey("Working order between Versions", t, func() {
+
+		Convey("equality", func() {
+			v1, _ := NewVersion("1.3.8")
+			v2, _ := NewVersion("1.3.8")
+			So(v1, ShouldResemble, v2)
+		})
+
+		Convey("between different release types", func() {
+			Convey("1.0.0 < 2.0.0", func() {
+				v1, _ := NewVersion("1.0.0")
+				v2, _ := NewVersion("2.0.0")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v2.Less(v1), ShouldBeFalse)
+				So(v1, ShouldNotResemble, v2)
+			})
+
+			Convey("2.2.1 < 2.4.0-beta", func() {
+				v1, _ := NewVersion("2.2.1")
+				v2, _ := NewVersion("2.4.0-beta")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v2.Less(v1), ShouldBeFalse)
+				So(v1, ShouldNotResemble, v2)
+			})
+
+			Convey("1.0.0 < 1.0.0-p", func() {
+				v1, _ := NewVersion("1.0.0")
+				v2, _ := NewVersion("1.0.0-p")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v2.Less(v1), ShouldBeFalse)
+				So(v1, ShouldNotResemble, v2)
+			})
+
+			Convey("1.0.0-rc < 1.0.0", func() {
+				v1, _ := NewVersion("1.0.0-rc")
+				v2, _ := NewVersion("1.0.0")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v1, ShouldNotResemble, v2)
+			})
+
+			Convey("1.0.0-pre < 1.0.0-rc", func() {
+				v1, _ := NewVersion("1.0.0-pre")
+				v2, _ := NewVersion("1.0.0-rc")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v1, ShouldNotResemble, v2)
+			})
+
+			Convey("1.0.0-beta < 1.0.0-pre", func() {
+				v1, _ := NewVersion("1.0.0-beta")
+				v2, _ := NewVersion("1.0.0-pre")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v1, ShouldNotResemble, v2)
+			})
+
+			Convey("1.0.0-alpha < 1.0.0-beta", func() {
+				v1, _ := NewVersion("1.0.0-alpha")
+				v2, _ := NewVersion("1.0.0-beta")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v1, ShouldNotResemble, v2)
+			})
+		})
+
+		Convey("between same release types", func() {
+			Convey("1.0.0-p0 < 1.0.0-p1", func() {
+				v1, _ := NewVersion("1.0.0-p0")
+				v2, _ := NewVersion("1.0.0-p1")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v1, ShouldNotResemble, v2)
+			})
+		})
+
+		Convey("with release type specifier", func() {
+			Convey("1.0.0-rc4-alpha1 < 1.0.0-rc4", func() {
+				v1, _ := NewVersion("1.0.0-rc4-alpha1")
+				v2, _ := NewVersion("1.0.0-rc4")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v1, ShouldNotResemble, v2)
+			})
+		})
+
+		Convey("with builds", func() {
+			Convey("1.0.0+build14 < 1.0.0+build15", func() {
+				v1, _ := NewVersion("1.0.0+build14")
+				v2, _ := NewVersion("1.0.0+build15")
+				So(v1.Less(v2), ShouldBeTrue)
+				So(v1, ShouldNotResemble, v2)
+			})
+
+			Convey("1.0.0_pre20140722+build14 < 1.0.0_pre20140722+build15", func() {
+				v1, _ := NewVersion("1.0.0_pre20140722+build14")
+				v2, _ := NewVersion("1.0.0_pre20140722+build15")
+				So(v1, ShouldNotResemble, v2)
+				So(v1.Less(v2), ShouldBeTrue)
+			})
+		})
+
+	})
+
+	// see http://devmanual.gentoo.org/ebuild-writing/file-format/
+	Convey("Gentoo's example of order works.", t, func() {
+		v1, _ := NewVersion("1.0.0_alpha_pre")
+		v2, _ := NewVersion("1.0.0_alpha_rc1")
+		v3, _ := NewVersion("1.0.0_beta_pre")
+		v4, _ := NewVersion("1.0.0_beta_p1")
+		So(v1.version, ShouldResemble, [...]int{1, 0, 0, 0, alpha, 0, 0, 0, 0, pre, 0, 0, 0, 0})
+		So(v2.version, ShouldResemble, [...]int{1, 0, 0, 0, alpha, 0, 0, 0, 0, rc, 1, 0, 0, 0})
+		So(v3.version, ShouldResemble, [...]int{1, 0, 0, 0, beta, 0, 0, 0, 0, pre, 0, 0, 0, 0})
+		So(v4.version, ShouldResemble, [...]int{1, 0, 0, 0, beta, 0, 0, 0, 0, patch, 1, 0, 0, 0})
+
+		So(v1, ShouldNotResemble, v2)
+		So(v2, ShouldNotResemble, v3)
+		So(v3, ShouldNotResemble, v4)
+		So(v1.Less(v2), ShouldBeTrue)
+		So(v2.Less(v3), ShouldBeTrue)
+		So(v3.Less(v4), ShouldBeTrue)
+	})
+
+	Convey("Reject too long Versions.", t, func() {
+		Convey("with surplus digits", func() {
+			_, err := NewVersion("1.0.0.0.4")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("with too long parts", func() {
+			_, err := NewVersion("100000000000007000000000000000070000000000000.0.0")
+			So(err, ShouldNotBeNil)
+			_, err = NewVersion("1.0.0_alpha444444444444444444444444444444444444444")
+			So(err, ShouldNotBeNil)
+			_, err = NewVersion("1.0.0_alpha-rc444444444444444444444444444444444444")
+			So(err, ShouldNotBeNil)
+			_, err = NewVersion("1.0.0_alpha-rc1+build44444444444444444444444444444")
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestVersionOrder(t *testing.T) {
+
+	Convey("Version 1.2.3-alpha4 should be…", t, func() {
+		v1, _ := NewVersion("1.2.3-alpha4")
+
+		Convey("reasonably less than Version 1.2.3", func() {
+			v2, _ := NewVersion("1.2.3")
+			So(v1.limitedLess(v2), ShouldBeTrue)
+		})
+
+		Convey("reasonably less than Version 1.2.3-alpha4.0.0.1", func() {
+			v2, _ := NewVersion("1.2.3-alpha4.0.0.1")
+			So(v1.limitedLess(v2), ShouldBeTrue)
+		})
+
+		Convey("not reasonably less than 1.2.3-alpha4-p5", func() {
+			v2, _ := NewVersion("1.2.3-alpha4-p5")
+			So(v1.limitedLess(v2), ShouldBeFalse)
+		})
+	})
+
+}


### PR DESCRIPTION
Example of compose.yml with new feature used:

    namespace: example
      containers:
        main1:
           image: ubuntu:14.04.*
           cmd: ["/bin/sh", "-c", "echo hello1"]

         main2:
           image: ubuntu:~14
           cmd: ["/bin/sh", "-c", "echo hello2"]

