### PR TITLE
Fix Windows inability to handle a tilde as the home directory

### DIFF
--- a/vendor/src/github.com/grammarly/rocker/src/rocker/dockerclient/dockerclient.go
+++ b/vendor/src/github.com/grammarly/rocker/src/rocker/dockerclient/dockerclient.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -48,7 +50,8 @@ type Config struct {
 func NewConfig() *Config {
 	certPath := os.Getenv("DOCKER_CERT_PATH")
 	if certPath == "" {
-		certPath = "~/.docker"
+		usr, _ := user.Current()
+		certPath = filepath.Join(usr.HomeDir, ".docker")
 	}
 	host := os.Getenv("DOCKER_HOST")
 	if host == "" {


### PR DESCRIPTION
The default location of the certificate files starting with a "~" (tilde) character causes Windows to barf.  Follow some recommendations in http://stackoverflow.com/questions/17609732/expand-tilde-to-home-directory to fix.