### PR TITLE
Hard fork of grammarly/rocker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,17 @@ install:
 	chmod +x /usr/local/bin/rocker-compose
 
 cross: dist_dir
-	docker run --rm -ti -v $(shell pwd):/go/src/github.com/grammarly/rocker-compose \
+	docker run --rm -ti -v $(shell pwd):/go/src/github.com/snkozlov/rocker-compose \
 		-e GOOS=linux -e GOARCH=amd64 -e GO15VENDOREXPERIMENT=1 -e GOPATH=/go \
-		-w /go/src/github.com/grammarly/rocker-compose \
-		dockerhub.grammarly.io/golang-1.5.1-cross:v1 go build \
+		-w /go/src/github.com/snkozlov/rocker-compose \
+		golang go build \
 		-ldflags "-X main.Version=$(VERSION) -X main.GitCommit=$(GITCOMMIT) -X main.GitBranch=$(GITBRANCH) -X main.BuildTime=$(BUILDTIME)" \
 		-v -o ./dist/linux_amd64/rocker-compose
 
-	docker run --rm -ti -v $(shell pwd):/go/src/github.com/grammarly/rocker-compose \
+	docker run --rm -ti -v $(shell pwd):/go/src/github.com/snkozlov/rocker-compose \
 		-e GOOS=darwin -e GOARCH=amd64 -e GO15VENDOREXPERIMENT=1 -e GOPATH=/go \
-		-w /go/src/github.com/grammarly/rocker-compose \
-		dockerhub.grammarly.io/golang-1.5.1-cross:v1 go build \
+		-w /go/src/github.com/snkozlov/rocker-compose \
+		golang go build \
 		-ldflags "-X main.Version=$(VERSION) -X main.GitCommit=$(GITCOMMIT) -X main.GitBranch=$(GITBRANCH) -X main.BuildTime=$(BUILDTIME)" \
 		-v -o ./dist/darwin_amd64/rocker-compose
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # rocker-compose
 
-[![Build Status](https://travis-ci.org/grammarly/rocker-compose.svg?branch=master)](https://travis-ci.org/grammarly/rocker-compose) 
-
 Docker composition tool with idempotency features for deploying apps composed of multiple containers. It's intended to be used in the following cases:
 
 1. Deploying containerized apps to servers

--- a/README.md
+++ b/README.md
@@ -733,6 +733,16 @@ container-5
 
 See [this example](#dynamic-scaling) of using `seq` for dynamically scaling containers.
 
+###### {{ getenv *key* }} 
+Get environment variable. Returns string.
+```
+{{ $i := getenv "TEST_STUFF" }}
+```
+
+```
+TEST_STUFF=1 rocker-compose
+```
+
 # Dynamic scaling
 Sometimes you need to dynamically set the number of containers to be started. `docker-compose` has [scale](https://docs.docker.com/compose/cli/#scale) command that does exactly what we want. With `rocker-compose` we can template the configuration with the help of the `seq` generator:
 

--- a/main.go
+++ b/main.go
@@ -31,10 +31,10 @@ import (
 	"time"
 
 	"github.com/go-yaml/yaml"
-	"github.com/grammarly/rocker-compose/src/compose"
-	"github.com/grammarly/rocker-compose/src/compose/ansible"
-	"github.com/grammarly/rocker-compose/src/compose/config"
-	"github.com/grammarly/rocker-compose/src/compose/tarmaker"
+	"github.com/snkozlov/rocker-compose/src/compose"
+	"github.com/snkozlov/rocker-compose/src/compose/ansible"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/compose/tarmaker"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"

--- a/main.go
+++ b/main.go
@@ -516,6 +516,9 @@ func initComposeConfig(ctx *cli.Context, dockerCli *docker.Client) *config.Confi
 			}
 			return *bridgeIP, nil
 		},
+                "getenv": func(key string) (ip string, err error) {
+                       return os.Getenv(key), nil
+                },
 	}
 
 	if file != "-" {

--- a/src/compose/client.go
+++ b/src/compose/client.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/grammarly/rocker-compose/src/compose/config"
-	"github.com/grammarly/rocker-compose/src/util"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/util"
 
 	"github.com/grammarly/rocker/src/dockerclient"
 	"github.com/grammarly/rocker/src/imagename"

--- a/src/compose/client_test.go
+++ b/src/compose/client_test.go
@@ -18,7 +18,7 @@ package compose
 
 import (
 	"fmt"
-	"github.com/grammarly/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
 	"strings"
 	"testing"
 	"time"

--- a/src/compose/compose.go
+++ b/src/compose/compose.go
@@ -22,8 +22,8 @@ package compose
 
 import (
 	"fmt"
-	"github.com/grammarly/rocker-compose/src/compose/ansible"
-	"github.com/grammarly/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/compose/ansible"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
 	"strings"
 	"time"
 

--- a/src/compose/container.go
+++ b/src/compose/container.go
@@ -17,8 +17,8 @@
 package compose
 
 import (
-	"github.com/grammarly/rocker-compose/src/compose/config"
-	"github.com/grammarly/rocker-compose/src/util"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/util"
 	"strings"
 	"time"
 

--- a/src/compose/container_test.go
+++ b/src/compose/container_test.go
@@ -17,7 +17,7 @@
 package compose
 
 import (
-	"github.com/grammarly/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
 	"testing"
 	"time"
 

--- a/src/compose/diff.go
+++ b/src/compose/diff.go
@@ -18,7 +18,7 @@ package compose
 
 import (
 	"fmt"
-	"github.com/grammarly/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
 )
 
 // Diff describes a comparison functionality of two container sets: expected and actual

--- a/src/compose/diff_test.go
+++ b/src/compose/diff_test.go
@@ -18,7 +18,7 @@ package compose
 
 import (
 	"fmt"
-	"github.com/grammarly/rocker-compose/src/compose/config"
+	"github.com/snkozlov/rocker-compose/src/compose/config"
 	"testing"
 
 	"github.com/grammarly/rocker/src/imagename"


### PR DESCRIPTION
Since grammarly/rocker-compose is unsupported at the moment, best decision should be to maintain forked version.